### PR TITLE
Test for Windows 8.1 pinned tile attempts to resolve case sensitive browser configuration file, resulting in incorrect test results

### DIFF
--- a/lib/checks/check-ie11tiles.js
+++ b/lib/checks/check-ie11tiles.js
@@ -96,7 +96,7 @@ function checkConfigFile(website) {
     if(configTag.length > 0){
         url = website.url.resolve($(configTag[0]).attr('content'));
     } else {
-        url = website.url.resolve('browserConfig.xml');
+        url = website.url.resolve('browserconfig.xml');
     }
 
     request(url, function (error, response, body) {


### PR DESCRIPTION
The test to check if a website has Windows 8.1 pinned tile support attempts to resolve `browserConfig.xml`, which is throwing a HTTP 404 on some servers that do in fact have a `browserconfig.xml` file. It seems this URL is case sensitive for some websites, causing the http://www.modern.ie/en-us/report website to report that a website does not have Windows 8.1 pinned tile support when in fact it does.

The documentation on MSDN also references the `browserconfig.xml` casing here: http://msdn.microsoft.com/en-us/library/ie/dn320426(v=vs.85).aspx
